### PR TITLE
Change how packet size limit are handled

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::error::TryRecvError;
 use tokio::task::JoinHandle;
 
 use crate::connection::IrohConnection;
-use crate::{ALPN, IrohRuntime, MAX_PACKET_SIZE};
+use crate::{ALPN, IrohRuntime};
 
 enum ClientStatus {
     Connecting(JoinHandle<anyhow::Result<(Endpoint, i32, IrohConnection)>>),
@@ -168,7 +168,11 @@ impl IMultiplayerPeerExtension for IrohClient {
     }
 
     fn get_max_packet_size(&self) -> i32 {
-        MAX_PACKET_SIZE as i32
+        if self.transfer_mode == TransferMode::RELIABLE {
+            u16::MAX as i32
+        } else {
+            1024
+        }
     }
 
     fn get_available_packet_count(&self) -> i32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use tokio::{
 };
 
 const ALPN: &[u8] = b"godot-iroh/0.1";
-const MAX_PACKET_SIZE: usize = 1024;
 
 mod client;
 mod connection;

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,8 +8,8 @@ use godot::prelude::*;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{Receiver, Sender, channel};
 
+use crate::IrohRuntime;
 use crate::connection::{IrohConnection, IrohListener};
-use crate::{IrohRuntime, MAX_PACKET_SIZE};
 
 #[derive(GodotClass)]
 #[class(tool, no_init, base=MultiplayerPeerExtension)]
@@ -160,7 +160,11 @@ impl IMultiplayerPeerExtension for IrohServer {
     }
 
     fn get_max_packet_size(&self) -> i32 {
-        MAX_PACKET_SIZE as i32
+        if self.transfer_mode == TransferMode::RELIABLE {
+            u16::MAX as i32
+        } else {
+            1024
+        }
     }
 
     fn get_available_packet_count(&self) -> i32 {


### PR DESCRIPTION
### Summary

This change enforces size limits for packets based on their type:

* **Unreliable packets**

  * Allowed up to the connection's estimated MTU.
  * Packets larger than the estimated MTU are still sent, but may be dropped by the network.
  * A **warning is logged whenever a packet exceeds the erestimate**, regardless of whether it’s ultimately dropped.

* **Reliable packets**

  * Maximum allowed size: **65,535 bytes** (`u16::MAX`).
  * Packets larger than this are **immediately discarded**.
  * An **error is emitted** when a reliable packet exceeds the limit.

Based on the discussion on #46 
Closes #62 